### PR TITLE
Add greenspace, RSF Project map, speed up GBIF with parquet

### DIFF
--- a/R/convert_gbif_to_parquet.R
+++ b/R/convert_gbif_to_parquet.R
@@ -1,0 +1,75 @@
+# ============================================================================
+# Convert GBIF Data to Parquet Format
+# ============================================================================
+# This script converts the GBIF .Rdata file to a parquet file with WKT geometry
+# for efficient querying with DuckDB spatial functions
+#
+# Run this script once to create the parquet file:
+#   source("R/convert_gbif_to_parquet.R")
+
+library(sf)
+library(dplyr)
+library(arrow)
+
+# ============================================================================
+# Load GBIF Data
+# ============================================================================
+cache_dir <- "data/cached"
+gbif_file <- file.path(cache_dir, "gbif_census_ndvi_anno.Rdata")
+
+if (!file.exists(gbif_file)) {
+  print("Downloading GBIF data from HuggingFace...")
+  dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
+  download.file(
+    "https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/gbif_census_ndvi_anno.Rdata",
+    gbif_file,
+    mode = "wb"
+  )
+}
+
+print("Loading GBIF .Rdata file...")
+load(gbif_file)
+
+# ============================================================================
+# Convert to Parquet with WKT Geometry
+# ============================================================================
+print("Converting to parquet format...")
+
+gbif_df <- sf_gbif |>
+  mutate(
+    # Add WKT geometry column for DuckDB spatial queries
+    geom_wkt = st_as_text(geometry),
+    # Extract coordinates for convenience
+    longitude = st_coordinates(geometry)[,1],
+    latitude = st_coordinates(geometry)[,2]
+  ) |>
+  # Drop sf geometry to save as regular data.frame
+  st_drop_geometry()
+
+# Verify we have the key columns
+required_cols <- c("species", "class", "family", "GEOID", "medincE", 
+                   "ndvi_sentinel", "institutionCode", "geom_wkt", 
+                   "longitude", "latitude")
+missing_cols <- setdiff(required_cols, names(gbif_df))
+if (length(missing_cols) > 0) {
+  stop("Missing required columns: ", paste(missing_cols, collapse = ", "))
+}
+
+# ============================================================================
+# Write to Parquet
+# ============================================================================
+output_dir <- "data/output"
+dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+output_file <- file.path(output_dir, "gbif_census_ndvi_anno.parquet")
+
+print(paste("Writing to", output_file, "..."))
+write_parquet(gbif_df, output_file)
+
+# ============================================================================
+# Summary
+# ============================================================================
+print("✓ Conversion complete!")
+print(paste("  Rows:", nrow(gbif_df)))
+print(paste("  Columns:", ncol(gbif_df)))
+print(paste("  File size:", round(file.size(output_file) / 1024^2, 2), "MB"))
+print(paste("  Location:", output_file))

--- a/R/setup.R
+++ b/R/setup.R
@@ -75,17 +75,25 @@ ndvi <- terra::rast(ndvi_file)
 
 
 
-# -- GBIF data
-# Load what is basically inter_gbif !!!!! 
-# load("data/sf_gbif.Rdata")  # => sf_gbif
-gbif_file <- file.path(cache_dir, "gbif_census_ndvi_anno.Rdata")
-download_if_missing(
-  "https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/gbif_census_ndvi_anno.Rdata",
-  gbif_file,
-  "GBIF data"
-)
-load(gbif_file)
-vect_gbif <- vect(sf_gbif)
+# # -- GBIF data
+# # Load what is basically inter_gbif !!!!! 
+# # load("data/sf_gbif.Rdata")  # => sf_gbif
+# gbif_file <- file.path(cache_dir, "gbif_census_ndvi_anno.Rdata")
+# download_if_missing(
+#   "https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/gbif_census_ndvi_anno.Rdata",
+#   gbif_file,
+#   "GBIF data"
+# )
+# load(gbif_file)
+# vect_gbif <- vect(sf_gbif)
+
+# -- GBIF data (now loaded via DuckDB in app.R server function)
+# Verify parquet file exists
+gbif_parquet <- "data/output/gbif_census_ndvi_anno.parquet"
+if (!file.exists(gbif_parquet)) {
+  stop("GBIF parquet file not found. Please run: source('R/convert_gbif_to_parquet.R')")
+}
+print("GBIF parquet file verified")
 
 # -- Precomputed CBG data
 cbg_file <- file.path(cache_dir, "cbg_vect_sf.Rdata")

--- a/R/setup.R
+++ b/R/setup.R
@@ -1,4 +1,10 @@
-# setup
+# ============================================================================
+# Setup: HuggingFace-optimized data loading
+# ============================================================================
+# This version uses GDAL virtual file system and temporary downloads
+# for efficient loading in cloud/ephemeral environments like HuggingFace Spaces.
+# For local development with persistent caching, use setup_local.R instead.
+
 require(shinyjs)
 library(shiny)
 library(shinydashboard)
@@ -17,92 +23,40 @@ library(sjlabelled)
 library(bslib)
 library(shinycssloaders)
 
-# ------------------------------------------------
-# 1) API Keys
-# ------------------------------------------------
+# ============================================================================
+# API Keys
+# ============================================================================
 mapbox_token <- "pk.eyJ1Ijoia3dhbGtlcnRjdSIsImEiOiJjbHc3NmI0cDMxYzhyMmt0OXBiYnltMjVtIn0.Thtu6WqIhOfin6AykskM2g" 
-# mb_access_token(mapbox_token, install = FALSE)
 
 # ============================================================================
-# Setup: Cache directory and download helper
-# ============================================================================
-cache_dir <- "data/cached"
-if (!dir.exists(cache_dir)) {
-  dir.create(cache_dir, recursive = TRUE)
-}
-
-download_if_missing <- function(url, destfile, name = basename(destfile)) {
-  if (!file.exists(destfile)) {
-    print(paste("Downloading", name, "from HuggingFace..."))
-    download.file(url, destfile, mode = "wb")
-  } else {
-    print(paste("Loading", name, "from cache"))
-  }
-}
-
-# ============================================================================
-# Load Data
+# Load Data from HuggingFace
 # ============================================================================
 
-# -- Greenspace
-greenspace_shp <- file.path(cache_dir, "greenspaces_osm_nad83.shp")
-if (!file.exists(greenspace_shp)) {
-  print("Downloading greenspaces_osm_nad83.shp from HuggingFace...")
-  st_read("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/greenspaces_osm_nad83.shp", quiet = TRUE) |>
-    st_write(greenspace_shp, quiet = TRUE)
-} else {
-  print("Loading greenspaces_osm_nad83.shp from cache")
-}
-osm_greenspace <- st_read(greenspace_shp, quiet = TRUE) |>
+# -- Greenspace (read directly from URL via GDAL virtual file system)
+osm_greenspace <- st_read("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/greenspaces_osm_nad83.shp", quiet = TRUE) |>
   st_transform(4326)
+
 if (!"name" %in% names(osm_greenspace)) {
   osm_greenspace$name <- "Unnamed Greenspace"
 }
 
-# -- Greenspace Distance Rasters
-print("Loading greenspace distance rasters from data/output/")
-greenspace_dist_raster <- terra::rast("data/output/nearest_greenspace_dist.tif")
-greenspace_osmid_raster <- terra::rast("data/output/nearest_greenspace_osmid.tif")
+# -- Greenspace Distance Rasters (read directly from URL via GDAL virtual file system)
+greenspace_dist_raster <- terra::rast("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/nearest_greenspace_dist.tif")
+greenspace_osmid_raster <- terra::rast("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/nearest_greenspace_osmid.tif")
 
-# -- NDVI Raster
-ndvi_file <- file.path(cache_dir, "SF_EastBay_NDVI_Sentinel_10.tif")
-download_if_missing(
-  "https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/SF_EastBay_NDVI_Sentinel_10.tif",
-  ndvi_file,
-  "NDVI raster"
+# -- NDVI Raster (read directly from URL via GDAL virtual file system)
+ndvi <- terra::rast("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/SF_EastBay_NDVI_Sentinel_10.tif")
+
+# -- GBIF data (loaded via DuckDB parquet in app.R server function)
+# DuckDB can read parquet files directly from URLs
+gbif_parquet <- "https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/gbif_census_ndvi_anno.parquet"
+
+# -- Precomputed CBG data (download to /tmp and load)
+download.file(
+  'https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/cbg_vect_sf.Rdata',
+  '/tmp/cbg_vect_sf.Rdata'
 )
-ndvi <- terra::rast(ndvi_file)
-
-
-
-# # -- GBIF data
-# # Load what is basically inter_gbif !!!!! 
-# # load("data/sf_gbif.Rdata")  # => sf_gbif
-# gbif_file <- file.path(cache_dir, "gbif_census_ndvi_anno.Rdata")
-# download_if_missing(
-#   "https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/gbif_census_ndvi_anno.Rdata",
-#   gbif_file,
-#   "GBIF data"
-# )
-# load(gbif_file)
-# vect_gbif <- vect(sf_gbif)
-
-# -- GBIF data (now loaded via DuckDB in app.R server function)
-# Verify parquet file exists
-gbif_parquet <- "data/output/gbif_census_ndvi_anno.parquet"
-if (!file.exists(gbif_parquet)) {
-  stop("GBIF parquet file not found. Please run: source('R/convert_gbif_to_parquet.R')")
-}
-print("GBIF parquet file verified")
-
-# -- Precomputed CBG data
-cbg_file <- file.path(cache_dir, "cbg_vect_sf.Rdata")
-download_if_missing(
-  "https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/cbg_vect_sf.Rdata",
-  cbg_file,
-  "CBG data"
-)
-load(cbg_file)
+load('/tmp/cbg_vect_sf.Rdata')
 
 if (!"unique_species" %in% names(cbg_vect_sf)) {
   cbg_vect_sf$unique_species <- cbg_vect_sf$n_species
@@ -117,81 +71,13 @@ if (!"ndvi_mean" %in% names(cbg_vect_sf)) {
   cbg_vect_sf$ndvi_mean <- cbg_vect_sf$ndvi_sentinel
 }
 
-# -- Hotspots/Coldspots
-hotspots_shp <- file.path(cache_dir, "hotspots.shp")
-if (!file.exists(hotspots_shp)) {
-  print("Downloading hotspots.shp from HuggingFace...")
-  st_read("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/hotspots.shp", quiet = TRUE) |>
-    st_write(hotspots_shp, quiet = TRUE)
-} else {
-  print("Loading hotspots.shp from cache")
-}
-biodiv_hotspots <- st_read(hotspots_shp, quiet = TRUE) |> st_transform(4326)
-
-coldspots_shp <- file.path(cache_dir, "coldspots.shp")
-if (!file.exists(coldspots_shp)) {
-  print("Downloading coldspots.shp from HuggingFace...")
-  st_read("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/coldspots.shp", quiet = TRUE) |>
-    st_write(coldspots_shp, quiet = TRUE)
-} else {
-  print("Loading coldspots.shp from cache")
-}
-biodiv_coldspots <- st_read(coldspots_shp, quiet = TRUE) |> st_transform(4326)
-
-# -- RSF Program Projects
-print("Loading RSF Program Projects from data/source/")
-rsf_projects <- st_read("data/source/RSF_Program_Projects_polygons.gpkg", quiet = TRUE) |> 
+# -- Hotspots/Coldspots (read directly from URL via GDAL virtual file system)
+biodiv_hotspots <- st_read("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/hotspots.shp", quiet = TRUE) |>
   st_transform(4326)
 
+biodiv_coldspots <- st_read("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/coldspots.shp", quiet = TRUE) |>
+  st_transform(4326)
 
-
-# 
-# # Community Organizations shapefile
-# # For now simulate
-# 
-# # Define San Francisco bounding box coordinates
-# sf_bbox <- st_bbox(c(
-#   xmin = -122.5247,  # Western longitude
-#   ymin = 37.7045,     # Southern latitude
-#   xmax = -122.3569,   # Eastern longitude
-#   ymax = 37.8334       # Northern latitude
-# ), crs = st_crs(4326))  # WGS84 CRS
-# 
-# # Convert bounding box to polygon
-# sf_boundary <- st_as_sfc(sf_bbox) %>% st_make_valid()
-# 
-# # Transform boundary to projected CRS for accurate buffering (EPSG:3310)
-# sf_boundary_proj <- st_transform(sf_boundary, 3310)
-# 
-# # Set seed for reproducibility
-# set.seed(123)
-# 
-# # Simulate 20 random points within San Francisco boundary
-# community_points <- st_sample(sf_boundary_proj, size = 20, type = "random")
-# 
-# # Convert to sf object with POINT geometry and assign unique names
-# community_points_sf <- st_sf(
-#   NAME = paste("Community Org", 1:20),
-#   geometry = community_points
-# )
-# # Select first 3 points to buffer
-# buffered_points_sf <- community_points_sf[1:3, ] %>%
-#   st_buffer(dist = 100)  # Buffer distance in meters
-# 
-# # Update the NAME column to indicate buffered areas
-# buffered_points_sf$NAME <- paste(buffered_points_sf$NAME, "Area")
-# community_points_sf <- st_transform(community_points_sf, 4326)
-# buffered_points_sf <- st_transform(buffered_points_sf, 4326)
-# 
-# # Combine points and polygons into one sf object
-# community_orgs <- bind_rows(
-#   community_points_sf,
-#   buffered_points_sf
-# )
-# 
-# # View the combined dataset
-# print(community_orgs)
-# 
-# community_points_only <- community_orgs %>% filter(st_geometry_type(geometry) == "POINT")
-# community_polygons_only <- community_orgs %>% filter(st_geometry_type(geometry) == "POLYGON")
-# 
+# -- RSF Program Projects (read directly from URL via GDAL virtual file system)
+rsf_projects <- st_read("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/RSF_Program_Projects_polygons.gpkg", quiet = TRUE) |> 
+  st_transform(4326)

--- a/R/setup_local.R
+++ b/R/setup_local.R
@@ -1,0 +1,197 @@
+# setup
+require(shinyjs)
+library(shiny)
+library(shinydashboard)
+library(leaflet)
+library(mapboxapi)
+library(tidyverse)
+library(tidycensus)
+library(sf)
+library(DT)
+library(RColorBrewer)
+library(terra)       
+library(data.table)
+library(mapview)   
+library(sjPlot)    
+library(sjlabelled)
+library(bslib)
+library(shinycssloaders)
+
+# ------------------------------------------------
+# 1) API Keys
+# ------------------------------------------------
+mapbox_token <- "pk.eyJ1Ijoia3dhbGtlcnRjdSIsImEiOiJjbHc3NmI0cDMxYzhyMmt0OXBiYnltMjVtIn0.Thtu6WqIhOfin6AykskM2g" 
+# mb_access_token(mapbox_token, install = FALSE)
+
+# ============================================================================
+# Setup: Cache directory and download helper
+# ============================================================================
+cache_dir <- "data/cached"
+if (!dir.exists(cache_dir)) {
+  dir.create(cache_dir, recursive = TRUE)
+}
+
+download_if_missing <- function(url, destfile, name = basename(destfile)) {
+  if (!file.exists(destfile)) {
+    print(paste("Downloading", name, "from HuggingFace..."))
+    download.file(url, destfile, mode = "wb")
+  } else {
+    print(paste("Loading", name, "from cache"))
+  }
+}
+
+# ============================================================================
+# Load Data
+# ============================================================================
+
+# -- Greenspace
+greenspace_shp <- file.path(cache_dir, "greenspaces_osm_nad83.shp")
+if (!file.exists(greenspace_shp)) {
+  print("Downloading greenspaces_osm_nad83.shp from HuggingFace...")
+  st_read("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/greenspaces_osm_nad83.shp", quiet = TRUE) |>
+    st_write(greenspace_shp, quiet = TRUE)
+} else {
+  print("Loading greenspaces_osm_nad83.shp from cache")
+}
+osm_greenspace <- st_read(greenspace_shp, quiet = TRUE) |>
+  st_transform(4326)
+if (!"name" %in% names(osm_greenspace)) {
+  osm_greenspace$name <- "Unnamed Greenspace"
+}
+
+# -- Greenspace Distance Rasters
+print("Loading greenspace distance rasters from data/output/")
+greenspace_dist_raster <- terra::rast("data/output/nearest_greenspace_dist.tif")
+greenspace_osmid_raster <- terra::rast("data/output/nearest_greenspace_osmid.tif")
+
+# -- NDVI Raster
+ndvi_file <- file.path(cache_dir, "SF_EastBay_NDVI_Sentinel_10.tif")
+download_if_missing(
+  "https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/SF_EastBay_NDVI_Sentinel_10.tif",
+  ndvi_file,
+  "NDVI raster"
+)
+ndvi <- terra::rast(ndvi_file)
+
+
+
+# # -- GBIF data
+# # Load what is basically inter_gbif !!!!! 
+# # load("data/sf_gbif.Rdata")  # => sf_gbif
+# gbif_file <- file.path(cache_dir, "gbif_census_ndvi_anno.Rdata")
+# download_if_missing(
+#   "https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/gbif_census_ndvi_anno.Rdata",
+#   gbif_file,
+#   "GBIF data"
+# )
+# load(gbif_file)
+# vect_gbif <- vect(sf_gbif)
+
+# -- GBIF data (now loaded via DuckDB in app.R server function)
+# Verify parquet file exists
+gbif_parquet <- "data/output/gbif_census_ndvi_anno.parquet"
+if (!file.exists(gbif_parquet)) {
+  stop("GBIF parquet file not found. Please run: source('R/convert_gbif_to_parquet.R')")
+}
+print("GBIF parquet file verified")
+
+# -- Precomputed CBG data
+cbg_file <- file.path(cache_dir, "cbg_vect_sf.Rdata")
+download_if_missing(
+  "https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/cbg_vect_sf.Rdata",
+  cbg_file,
+  "CBG data"
+)
+load(cbg_file)
+
+if (!"unique_species" %in% names(cbg_vect_sf)) {
+  cbg_vect_sf$unique_species <- cbg_vect_sf$n_species
+}
+if (!"n_observations" %in% names(cbg_vect_sf)) {
+  cbg_vect_sf$n_observations <- cbg_vect_sf$n
+}
+if (!"median_inc" %in% names(cbg_vect_sf)) {
+  cbg_vect_sf$median_inc <- cbg_vect_sf$medincE
+}
+if (!"ndvi_mean" %in% names(cbg_vect_sf)) {
+  cbg_vect_sf$ndvi_mean <- cbg_vect_sf$ndvi_sentinel
+}
+
+# -- Hotspots/Coldspots
+hotspots_shp <- file.path(cache_dir, "hotspots.shp")
+if (!file.exists(hotspots_shp)) {
+  print("Downloading hotspots.shp from HuggingFace...")
+  st_read("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/hotspots.shp", quiet = TRUE) |>
+    st_write(hotspots_shp, quiet = TRUE)
+} else {
+  print("Loading hotspots.shp from cache")
+}
+biodiv_hotspots <- st_read(hotspots_shp, quiet = TRUE) |> st_transform(4326)
+
+coldspots_shp <- file.path(cache_dir, "coldspots.shp")
+if (!file.exists(coldspots_shp)) {
+  print("Downloading coldspots.shp from HuggingFace...")
+  st_read("/vsicurl/https://huggingface.co/datasets/boettiger-lab/sf_biodiv_access/resolve/main/coldspots.shp", quiet = TRUE) |>
+    st_write(coldspots_shp, quiet = TRUE)
+} else {
+  print("Loading coldspots.shp from cache")
+}
+biodiv_coldspots <- st_read(coldspots_shp, quiet = TRUE) |> st_transform(4326)
+
+# -- RSF Program Projects
+print("Loading RSF Program Projects from data/source/")
+rsf_projects <- st_read("data/source/RSF_Program_Projects_polygons.gpkg", quiet = TRUE) |> 
+  st_transform(4326)
+
+
+
+# 
+# # Community Organizations shapefile
+# # For now simulate
+# 
+# # Define San Francisco bounding box coordinates
+# sf_bbox <- st_bbox(c(
+#   xmin = -122.5247,  # Western longitude
+#   ymin = 37.7045,     # Southern latitude
+#   xmax = -122.3569,   # Eastern longitude
+#   ymax = 37.8334       # Northern latitude
+# ), crs = st_crs(4326))  # WGS84 CRS
+# 
+# # Convert bounding box to polygon
+# sf_boundary <- st_as_sfc(sf_bbox) %>% st_make_valid()
+# 
+# # Transform boundary to projected CRS for accurate buffering (EPSG:3310)
+# sf_boundary_proj <- st_transform(sf_boundary, 3310)
+# 
+# # Set seed for reproducibility
+# set.seed(123)
+# 
+# # Simulate 20 random points within San Francisco boundary
+# community_points <- st_sample(sf_boundary_proj, size = 20, type = "random")
+# 
+# # Convert to sf object with POINT geometry and assign unique names
+# community_points_sf <- st_sf(
+#   NAME = paste("Community Org", 1:20),
+#   geometry = community_points
+# )
+# # Select first 3 points to buffer
+# buffered_points_sf <- community_points_sf[1:3, ] %>%
+#   st_buffer(dist = 100)  # Buffer distance in meters
+# 
+# # Update the NAME column to indicate buffered areas
+# buffered_points_sf$NAME <- paste(buffered_points_sf$NAME, "Area")
+# community_points_sf <- st_transform(community_points_sf, 4326)
+# buffered_points_sf <- st_transform(buffered_points_sf, 4326)
+# 
+# # Combine points and polygons into one sf object
+# community_orgs <- bind_rows(
+#   community_points_sf,
+#   buffered_points_sf
+# )
+# 
+# # View the combined dataset
+# print(community_orgs)
+# 
+# community_points_only <- community_orgs %>% filter(st_geometry_type(geometry) == "POINT")
+# community_polygons_only <- community_orgs %>% filter(st_geometry_type(geometry) == "POLYGON")
+# 

--- a/app.R
+++ b/app.R
@@ -32,7 +32,8 @@ source('R/setup.R') # Load necessary data (annotated gbif, annotated cbg, ndvi)
 # ============================================================================
 con_temp <- dbConnect(duckdb::duckdb(), dbdir = ":memory:")
 dbExecute(con_temp, "INSTALL spatial; LOAD spatial;")
-gbif_tab_temp <- tbl(con_temp, "read_parquet('data/output/gbif_census_ndvi_anno.parquet')")
+dbExecute(con_temp, "INSTALL httpfs; LOAD httpfs;")
+gbif_tab_temp <- tbl(con_temp, paste0("read_parquet('", gbif_parquet, "')"))
 
 gbif_classes <- gbif_tab_temp |> distinct(class) |> collect() |> pull(class) |> sort()
 gbif_families <- gbif_tab_temp |> distinct(family) |> collect() |> pull(family) |> sort()
@@ -339,9 +340,10 @@ server <- function(input, output, session) {
   # ============================================================================
   con <- dbConnect(duckdb::duckdb(), dbdir = ":memory:")
   dbExecute(con, "INSTALL spatial; LOAD spatial;")
+  dbExecute(con, "INSTALL httpfs; LOAD httpfs;")
   
   # Load GBIF parquet as table reference (reuse throughout session)
-  gbif_tab <- tbl(con, "read_parquet('data/output/gbif_census_ndvi_anno.parquet')")
+  gbif_tab <- tbl(con, paste0("read_parquet('", gbif_parquet, "')"))
   
   # Cleanup connection on session end
   onStop(function() {

--- a/app.R
+++ b/app.R
@@ -791,10 +791,10 @@ server <- function(input, output, session) {
     leafletProxy("isoMap") %>%
       addLayersControl(
         baseGroups = c("Street Map (Default)", "Satellite (ESRI)", "CartoDB.Positron"),
-        overlayGroups = c("Income", "Greenspace", "RSF Program Projects",
+        overlayGroups = c("Income", "Greenspace", "Greenspace Distance", "RSF Program Projects",
                           "Hotspots (KnowBR)", "Coldspots (KnowBR)",
                           "Species Richness", "Data Availability",
-                          "Isochrones", "NDVI Raster", "Greenspace Distance"),
+                          "Isochrones", "NDVI Raster"),
         options = layersControlOptions(collapsed = FALSE)
       )
   })

--- a/app.R
+++ b/app.R
@@ -421,6 +421,28 @@ server <- function(input, output, session) {
       ) %>%
       
       addPolygons(
+        data = rsf_projects,
+        group = "RSF Program Projects",
+        fillColor = "purple",
+        fillOpacity = 0.3,
+        color = "purple",
+        weight = 1,
+        label = ~prj_name,
+        highlightOptions = highlightOptions(
+          weight = 5,
+          color = "blue",
+          fillOpacity = 0.5,
+          bringToFront = TRUE
+        ),
+        labelOptions = labelOptions(
+          style = list("font-weight" = "bold", "color" = "blue"),
+          textsize = "12px",
+          direction = "auto",
+          noHide = FALSE # Labels appear on hover
+        )
+      ) %>%
+      
+      addPolygons(
         data = biodiv_hotspots,
         group = "Hotspots (KnowBR)",
         fillColor = "firebrick",
@@ -501,7 +523,7 @@ server <- function(input, output, session) {
       setView(lng = -122.4194, lat = 37.7749, zoom = 12) %>%
       addLayersControl(
         baseGroups    = c("Street Map (Default)", "Satellite (ESRI)", "CartoDB.Positron"),
-        overlayGroups = c("Income", "Greenspace", 
+        overlayGroups = c("Income", "Greenspace", "RSF Program Projects",
                           "Hotspots (KnowBR)", "Coldspots (KnowBR)",
                           "Species Richness", "Data Availability",
                           "Isochrones", "NDVI Raster"),
@@ -509,6 +531,7 @@ server <- function(input, output, session) {
       ) %>%
       hideGroup("Income") %>%
       hideGroup("Greenspace") %>%
+      hideGroup("RSF Program Projects") %>%
       hideGroup("Hotspots (KnowBR)") %>%
       hideGroup("Coldspots (KnowBR)") %>%
       hideGroup("Species Richness") %>%
@@ -701,7 +724,7 @@ server <- function(input, output, session) {
     leafletProxy("isoMap") %>%
       addLayersControl(
         baseGroups = c("Street Map (Default)", "Satellite (ESRI)", "CartoDB.Positron"),
-        overlayGroups = c("Income", "Greenspace", 
+        overlayGroups = c("Income", "Greenspace", "RSF Program Projects",
                           "Hotspots (KnowBR)", "Coldspots (KnowBR)",
                           "Species Richness", "Data Availability",
                           "Isochrones", "NDVI Raster"),

--- a/app.R
+++ b/app.R
@@ -763,31 +763,32 @@ server <- function(input, output, session) {
     
     iso_union <- st_union(iso_data)
     iso_union_vect <- vect(iso_union)
-    ndvi_crop <- terra::crop(ndvi, iso_union_vect)
-    ndvi_mask <- terra::mask(ndvi_crop, iso_union_vect)
-    ndvi_vals <- values(ndvi_mask)
-    ndvi_vals <- ndvi_vals[!is.na(ndvi_vals)]
-    
-    if (length(ndvi_vals) > 0) {
-      ndvi_pal <- colorNumeric("YlGn", domain = range(ndvi_vals, na.rm = TRUE), na.color = "transparent")
-      
-      leafletProxy("isoMap") %>%
-        addRasterImage(
-          x = ndvi_mask,
-          colors = ndvi_pal,
-          opacity = 0.7,
-          project = TRUE,
-          group = "NDVI Raster"
-        ) %>%
-        removeControl(layerId = "ndvi_legend") %>%
-        addLegend(
-          position = "bottomright",
-          pal = ndvi_pal,
-          values = ndvi_vals,
-          title = "NDVI",
-          layerId = "ndvi_legend"
-        )
-    }
+    # COMMENTED OUT: Something wrong with NDVI file
+    # ndvi_crop <- terra::crop(ndvi, iso_union_vect)
+    # ndvi_mask <- terra::mask(ndvi_crop, iso_union_vect)
+    # ndvi_vals <- values(ndvi_mask)
+    # ndvi_vals <- ndvi_vals[!is.na(ndvi_vals)]
+    # 
+    # if (length(ndvi_vals) > 0) {
+    #   ndvi_pal <- colorNumeric("YlGn", domain = range(ndvi_vals, na.rm = TRUE), na.color = "transparent")
+    #   
+    #   leafletProxy("isoMap") %>%
+    #     addRasterImage(
+    #       x = ndvi_mask,
+    #       colors = ndvi_pal,
+    #       opacity = 0.7,
+    #       project = TRUE,
+    #       group = "NDVI Raster"
+    #     ) %>%
+    #     removeControl(layerId = "ndvi_legend") %>%
+    #     addLegend(
+    #       position = "bottomright",
+    #       pal = ndvi_pal,
+    #       values = ndvi_vals,
+    #       title = "NDVI",
+    #       layerId = "ndvi_legend"
+    #     )
+    # }
     
     # Ensure other layers remain
     leafletProxy("isoMap") %>%
@@ -920,12 +921,14 @@ server <- function(input, output, session) {
       gs_percent <- ifelse(iso_area_m2 > 0, 100 * gs_area_m2 / iso_area_m2, 0)
       
       # NDVI Calculation
-      poly_vect <- vect(poly_i)
-      ndvi_crop <- terra::crop(ndvi, poly_vect)
-      ndvi_mask <- terra::mask(ndvi_crop, poly_vect)
-      ndvi_vals <- values(ndvi_mask)
-      ndvi_vals <- ndvi_vals[!is.na(ndvi_vals)]
-      mean_ndvi <- ifelse(length(ndvi_vals) > 0, round(mean(ndvi_vals, na.rm=TRUE), 3), NA)
+      # COMMENTED OUT: Something wrong with NDVI file
+      # poly_vect <- vect(poly_i)
+      # ndvi_crop <- terra::crop(ndvi, poly_vect)
+      # ndvi_mask <- terra::mask(ndvi_crop, poly_vect)
+      # ndvi_vals <- values(ndvi_mask)
+      # ndvi_vals <- ndvi_vals[!is.na(ndvi_vals)]
+      mean_ndvi <- NA  # Temporarily set to NA while NDVI file is unavailable
+      # mean_ndvi <- ifelse(length(ndvi_vals) > 0, round(mean(ndvi_vals, na.rm=TRUE), 3), NA)
       
       # Intersection with GBIF data using DuckDB
       iso_wkt <- st_as_text(st_geometry(poly_i)[[1]])

--- a/app.R
+++ b/app.R
@@ -883,8 +883,13 @@ server <- function(input, output, session) {
     if (nrow(df) == 0) {
       return(DT::datatable(data.frame("Message" = "No isochrones generated yet.")))
     }
+    
+    # Select only the columns to display (excluding Greenspace_m2)
+    df_display <- df |>
+      select(-Greenspace_m2)
+    
     DT::datatable(
-      df,
+      df_display,
       colnames = c(
         "Mode"                 = "Mode",
         "Time (min)"           = "Time",
@@ -899,7 +904,6 @@ server <- function(input, output, session) {
         "Bird Species"         = "Bird_Species",
         "Mammal Species"       = "Mammal_Species",
         "Plant Species"        = "Plant_Species",
-        # "Greenspace (m²)"      = "Greenspace_m2",
         "Greenspace (%)"       = "Greenspace_percent"
       ),
       options = list(pageLength = 10, autoWidth = TRUE),
@@ -1016,7 +1020,7 @@ server <- function(input, output, session) {
     
     ggplot(df_plot, aes(x = IsoLabel)) +
       geom_col(aes(y = GBIF_Species), fill = "steelblue", alpha = 0.7) +
-      geom_line(aes(y = EstimatedPopulation / 1000, group = 1), color = "red", size = 1) +
+      geom_line(aes(y = EstimatedPopulation / 1000, group = 1), color = "red", linewidth = 1) +
       geom_point(aes(y = EstimatedPopulation / 1000), color = "red", size = 3) +
       labs(
         x = "Isochrone (Mode-Time)",

--- a/app.R
+++ b/app.R
@@ -1019,7 +1019,7 @@ server <- function(input, output, session) {
         "Plant Species"        = "Plant_Species",
         "Greenspace (%)"       = "Greenspace_percent"
       ),
-      options = list(pageLength = 10, autoWidth = TRUE),
+      options = list(pageLength = 10, autoWidth = TRUE, scrollX = TRUE),
       rownames = FALSE
     )
   })

--- a/app.R
+++ b/app.R
@@ -781,7 +781,8 @@ server <- function(input, output, session) {
           position = "bottomright",
           pal = ndvi_pal,
           values = ndvi_vals,
-          title = "NDVI"
+          title = "NDVI",
+          group = "NDVI Raster"
         )
     }
     

--- a/install.r
+++ b/install.r
@@ -15,7 +15,4 @@ install.packages(c("shinyjs",
 "sjlabelled",
 "bslib",
 "shinycssloaders",
-"duckdb",
-"DBI",
-"dbplyr",
-"arrow"))
+"duckdb"))

--- a/install.r
+++ b/install.r
@@ -14,4 +14,8 @@ install.packages(c("shinyjs",
 "sjPlot",    
 "sjlabelled",
 "bslib",
-"shinycssloaders"))
+"shinycssloaders",
+"duckdb",
+"DBI",
+"dbplyr",
+"arrow"))


### PR DESCRIPTION
This is copied form the email I sent you:

> Here's some updates on the RSF app that we had discussed. Here's my updated version: https://huggingface.co/spaces/avephill/Reimagining_SF_Shiny_App
> 
> 1. I added the greenspace raster layer which should speed up greenspace calculations. There's also a new Greenspace Distance layer in the map view
> 2. I added Lizzy's RSF Program Projects layer to the map. You can toggle it on and off
> 3. I converted the GBIF data from an .Rdata file to a .parquet. The gbif data was annotated with census data and ndvi, and I didn't see the script that did that. So instead of creating a gbif parquet with all species, I just converted the existing gbif data to a parquet and used that. It seems to have significantly speeded up runtime. If you can find where the gbif_census_ndvi_anno.Rdata was originally produced I can help expand it for more than just birds. I edited the app so it should be able to handle all (or at least a lot more) GBIF data without crashing or slowing down too much.